### PR TITLE
Add KTLS support to hurl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ option(BUILD_UBSAN          "Build with Undefined Behavior Sanitizer" OFF)
 option(BUILD_UDNS           "Build with udns (async dns support)" ON)
 option(BUILD_UBUNTU         "Build for Ubuntu" OFF)
 option(BUILD_CUSTOM_OPENSSL "Build for Ubuntu" OFF)
+option(BUILD_KTLS_SUPPORT   "Build with KTLS support - requires OpenSSL to be built with KTLS support as well" OFF)
 # ------------------------------------------------------------------------------
 # Display the current settings
 # ------------------------------------------------------------------------------
@@ -64,6 +65,7 @@ message("    Build with Undefined Behavior Sanitizer:   " "BUILD_UBSAN          
 message("    Build with udns support:                   " "BUILD_UDNS              " ${BUILD_UDNS})
 message("    Build for Ubuntu (adds package help):      " "BUILD_UBUNTU            " ${BUILD_UBUNTU})
 message("    Build for custom OpenSSL:                  " "BUILD_CUSTOM_OPENSSL    " ${BUILD_CUSTOM_OPENSSL})
+message("    Build with KTLS support:                   " "BUILD_KTLS_SUPPORT      " ${BUILD_KTLS_SUPPORT})
 message("")
 # ------------------------------------------------------------------------------
 # fortify options
@@ -168,9 +170,9 @@ ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # Link OpenSSL
 # ------------------------------------------------------------------------------
 if(BUILD_UBUNTU AND BUILD_CUSTOM_OPENSSL)
-  INCLUDE_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}/include")
-  set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/libssl.a")
-  set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/libcrypto.a")
+  	INCLUDE_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}/include")
+	set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/libssl.a")
+	set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/libcrypto.a")
   find_ubuntu_package(LIBZ zlib.h libz.a zlib1g zlib1g-dev)
   add_definitions(-DBUILD_CUSTOM_OPENSSL=1)
 elseif(BUILD_UBUNTU)
@@ -178,12 +180,14 @@ elseif(BUILD_UBUNTU)
   find_ubuntu_package(LIBCRYPTO openssl/crypto.h libcrypto.a libssl1.0.0 libssl-dev)
   find_ubuntu_package(LIBZ zlib.h libz.a zlib1g zlib1g-dev)
 else()
-   INCLUDE_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}/include")
-   set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/lib/libssl.a")
-   set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/lib/libcrypto.a")    
-   set(LIBRARIES ${LIBRARIES} pthread z)
-   # set(LIBRARIES ${LIBRARIES} pthread ssl crypto)
+    set(LIBRARIES ${LIBRARIES} pthread ssl crypto)
 endif()
+# ------------------------------------------------------------------------------
+# KTLS SUPPORT
+# ------------------------------------------------------------------------------
+if (BUILD_KTLS_SUPPORT)
+    add_definitions(-DKTLS_SUPPORT)
+endif()    
 # ------------------------------------------------------------------------------
 # Build PROFILER
 # ------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,11 @@ elseif(BUILD_UBUNTU)
   find_ubuntu_package(LIBCRYPTO openssl/crypto.h libcrypto.a libssl1.0.0 libssl-dev)
   find_ubuntu_package(LIBZ zlib.h libz.a zlib1g zlib1g-dev)
 else()
-  set(LIBRARIES ${LIBRARIES} pthread ssl crypto)
+   INCLUDE_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}/include")
+   set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/lib/libssl.a")
+   set(LIBRARIES ${LIBRARIES} "${BUILD_CUSTOM_OPENSSL}/lib/libcrypto.a")    
+   set(LIBRARIES ${LIBRARIES} pthread z)
+   # set(LIBRARIES ${LIBRARIES} pthread ssl crypto)
 endif()
 # ------------------------------------------------------------------------------
 # Build PROFILER

--- a/src/core/nconn/nconn.cc
+++ b/src/core/nconn/nconn.cc
@@ -245,7 +245,7 @@ int32_t nconn::nc_set_listening_nb(int32_t a_val)
 int32_t nconn::nc_set_accepting(int a_fd)
 {
         int32_t l_s;
-        l_s = ncset_accepting(a_fd);
+        l_s = ncset_accepting(a_fd); //function name typo?
         if(l_s != NC_STATUS_OK)
         {
                 return STATUS_ERROR;

--- a/src/core/nconn/nconn_tcp.cc
+++ b/src/core/nconn/nconn_tcp.cc
@@ -628,6 +628,21 @@ state_top:
         }
         // Set to connected state
         m_tcp_state = TCP_STATE_CONNECTED;
+        
+        // David S - KTLS enable - code borrowed from Openssl include/internal/ktls.h
+        
+        int tmp_ret = 0;                                                   
+        tmp_ret = setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+
+<<<<<<< HEAD
+=======
+        
+        printf("HURL CODE CHECK - in nconn_tcp::ncconnect() after m_tcp_state = TCP_STATE_CONNECTED .635.nconn_tcp.cc- After setsockopt value of tmp_ret is: %d and value of errno is: %d\n",tmp_ret,errno);
+
+>>>>>>> fb62bee... [WIP ktls_davids] Make the debug check for KTLS use more robust (will
+        // David S - KTLS enable  end
+        
+        
         // TODO Stats???
         //if(m_collect_stats_flag)
         //{

--- a/src/core/nconn/nconn_tcp.cc
+++ b/src/core/nconn/nconn_tcp.cc
@@ -635,8 +635,8 @@ state_top:
 
         //TODO: check for errors in setsockopt?? - shouldn't really be necessary
 
-        int tmp_ret = 0;                                                   
-        tmp_ret = setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+        //int tmp_ret = 0;                                                   
+        //tmp_ret = setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
 
         
         //printf("HURL CODE CHECK - in nconn_tcp::ncconnect() after m_tcp_state = TCP_STATE_CONNECTED .635.nconn_tcp.cc- After setsockopt value of tmp_ret is: %d and value of errno is: %d\n",tmp_ret,errno); //The purpose of this printf is to evaluate the return code and errno from setsockopt. Only really needed for debugging.

--- a/src/core/nconn/nconn_tcp.cc
+++ b/src/core/nconn/nconn_tcp.cc
@@ -631,15 +631,16 @@ state_top:
         
         // David S - KTLS enable - code borrowed from Openssl include/internal/ktls.h
         
+        setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+
+        //TODO: check for errors in setsockopt?? - shouldn't really be necessary
+
         int tmp_ret = 0;                                                   
         tmp_ret = setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
 
-<<<<<<< HEAD
-=======
         
-        printf("HURL CODE CHECK - in nconn_tcp::ncconnect() after m_tcp_state = TCP_STATE_CONNECTED .635.nconn_tcp.cc- After setsockopt value of tmp_ret is: %d and value of errno is: %d\n",tmp_ret,errno);
+        //printf("HURL CODE CHECK - in nconn_tcp::ncconnect() after m_tcp_state = TCP_STATE_CONNECTED .635.nconn_tcp.cc- After setsockopt value of tmp_ret is: %d and value of errno is: %d\n",tmp_ret,errno); //The purpose of this printf is to evaluate the return code and errno from setsockopt. Only really needed for debugging.
 
->>>>>>> fb62bee... [WIP ktls_davids] Make the debug check for KTLS use more robust (will
         // David S - KTLS enable  end
         
         

--- a/src/core/nconn/nconn_tcp.cc
+++ b/src/core/nconn/nconn_tcp.cc
@@ -629,20 +629,13 @@ state_top:
         // Set to connected state
         m_tcp_state = TCP_STATE_CONNECTED;
         
-        // David S - KTLS enable - code borrowed from Openssl include/internal/ktls.h
-        
-        setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
-
-        //TODO: check for errors in setsockopt?? - shouldn't really be necessary
-
-        //int tmp_ret = 0;                                                   
-        //tmp_ret = setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
-
-        
-        //printf("HURL CODE CHECK - in nconn_tcp::ncconnect() after m_tcp_state = TCP_STATE_CONNECTED .635.nconn_tcp.cc- After setsockopt value of tmp_ret is: %d and value of errno is: %d\n",tmp_ret,errno); //The purpose of this printf is to evaluate the return code and errno from setsockopt. Only really needed for debugging.
-
-        // David S - KTLS enable  end
-        
+#ifdef KTLS_SUPPORT
+             // David S - KTLS enable - code borrowed from Openssl include/internal/ktls.h
+             
+             setsockopt(m_fd, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+             
+             //TODO: check for errors in setsockopt?? - shouldn't really be necessary
+#endif
         
         // TODO Stats???
         //if(m_collect_stats_flag)

--- a/src/core/nconn/nconn_tcp.h
+++ b/src/core/nconn/nconn_tcp.h
@@ -26,6 +26,16 @@
 //: Includes
 //: ----------------------------------------------------------------------------
 #include "nconn.h"
+
+//David S - KTLS changes requires a #define for TCP_ULP - is only defined in /usr/include/linux/tcp.h (propbably from kernel version >= 4.13 when KTLS support was first added). Since KTLS is a linux only feature thus far, only the required define is repeated here (for code portability's sake - based on https://stackoverflow.com/questions/34121434/difference-in-netinet-tcp-h-vs-linux-tcp-h)
+#ifdef __linux__
+    #ifndef TCP_ULP
+    #define TCP_ULP 31
+    #endif
+#endif
+//David S - End
+
+
 namespace ns_hurl {
 //: ----------------------------------------------------------------------------
 //: \details: TODO

--- a/src/core/nconn/nconn_tls.cc
+++ b/src/core/nconn/nconn_tls.cc
@@ -323,6 +323,28 @@ int32_t show_tls_info(nconn *a_nconn)
         TRC_OUTPUT("+------------------------------------------------------------------------------+\n");
         TRC_OUTPUT("%s", ANSI_COLOR_OFF);
         SSL_SESSION_print_fp(stdout, m_tls_session);
+       
+        #ifdef KTLS_SUPPORT 
+            // Print KTLS info
+            if (BIO_get_ktls_send(SSL_get_wbio(l_tls)))
+            {
+                printf("%s\n","TX path is using KTLS");
+            }    
+            else
+            {
+                printf("%s\n","TX path is NOT using KTLS");
+            }
+                                                      
+            if (BIO_get_ktls_recv(SSL_get_rbio(l_tls)))
+            {
+                printf("%s\n","RX path is using KTLS");
+            }    
+            else
+            {
+                printf("%s\n","RX path is NOT using KTLS");
+            }
+        #endif
+
         //int32_t l_protocol_num = get_tls_info_protocol_num(l_tls);
         //std::string l_cipher = get_tls_info_cipher_str(l_tls);
         //std::string l_protocol = get_tls_info_protocol_str(l_protocol_num);
@@ -760,7 +782,7 @@ int32_t nconn_tls::set_opt(uint32_t a_opt, const void *a_buf, uint32_t a_len)
 
 BIO* nconn_tls::get_m_tls_bio()
 {
-    return this->m_tls_bio;
+    return m_tls_bio;
 }    
 
 // David S - End
@@ -1239,33 +1261,6 @@ ncconnect_state_top:
                         }
                 }
         
-        // David S - KTLS debug
-        // The m_tls_bio was kept for convenience, but it seems to be more robust
-        // to rather make use of the SSL_get_wbio/rbio functions when checking for KTLS
-        // since calls to SSL_set_fd exist elsewhere in the hurl source code which could 
-        // potentially 'free' the BIOs assigned to m_tls and thereafter create new BIOs
-        // and attach these to m_tls.
-        //if (BIO_get_ktls_send(m_tls_bio))
-        if (BIO_get_ktls_send(SSL_get_wbio(m_tls)))
-        {
-            printf("%s\n","TX is using KTLS");
-        }    
-        else
-        {
-            printf("%s\n","TX is NOT using KTLS");
-        }
-                                                  
-                                                  
-        //if (BIO_get_ktls_recv(m_tls_bio))
-        if (BIO_get_ktls_recv(SSL_get_rbio(m_tls)))
-        {
-            printf("%s\n","RX is using KTLS");
-        }    
-        else
-        {
-            printf("%s\n","RX is NOT using KTLS");
-        }
-        // David S -End KTLS debug
                 // -----------------------------------------
                 // get negotiated alpn...
                 // -----------------------------------------

--- a/src/core/nconn/nconn_tls.h
+++ b/src/core/nconn/nconn_tls.h
@@ -26,6 +26,10 @@
 //: includes
 //: ----------------------------------------------------------------------------
 #include "nconn/nconn_tcp.h"
+// David S - BIO includes
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+// End David S
 //: ----------------------------------------------------------------------------
 //: ext fwd decl's
 //: ----------------------------------------------------------------------------
@@ -93,6 +97,9 @@ public:
           nconn_tcp(),
           m_tls_ctx(NULL),
           m_tls(NULL),
+          // David S - BIO changes
+          m_tls_bio(NULL),
+          // David S - End
           m_tls_opt_verify(false),
           m_tls_opt_sni(false),
           m_tls_opt_verify_allow_self_signed(false),
@@ -111,6 +118,8 @@ public:
         };
         // Destructor
         ~nconn_tls() {};
+        
+        //Public methods
         int32_t set_opt(uint32_t a_opt, const void *a_buf, uint32_t a_len);
         int32_t get_opt(uint32_t a_opt, void **a_buf, uint32_t *a_len);
         bool is_listening(void) {return (m_tls_state == TLS_STATE_LISTENING);};
@@ -122,6 +131,9 @@ public:
                                          (m_tls_state == TLS_STATE_TLS_ACCEPTING) ||
                                          (m_tls_state == TLS_STATE_TLS_ACCEPTING_WANT_READ) ||
                                          (m_tls_state == TLS_STATE_TLS_ACCEPTING_WANT_WRITE));};
+        //David S
+        BIO* get_m_tls_bio();
+        //David S - End
         // -------------------------------------------------
         // virtual methods
         // -------------------------------------------------
@@ -135,6 +147,8 @@ public:
         int32_t ncset_listening_nb(int32_t a_val);
         int32_t ncset_accepting(int a_fd);
         int32_t ncset_connected(void);
+
+        
 private:
         // -------------------------------------------------
         // Private methods
@@ -149,6 +163,9 @@ private:
         // -------------------------------------------------
         SSL_CTX * m_tls_ctx;
         SSL *m_tls;
+        // David S - TLS BIO additions
+        BIO *m_tls_bio;
+        // End David S
         bool m_tls_opt_verify;
         bool m_tls_opt_sni;
         bool m_tls_opt_verify_allow_self_signed;

--- a/src/core/support/tls_util.cc
+++ b/src/core/support/tls_util.cc
@@ -182,6 +182,11 @@ void tls_init(void)
         SSL_library_init();
         // Bring in and register error messages
         ERR_load_crypto_strings();
+        
+        // David S - BIO changes
+        ERR_load_BIO_strings();
+        // David S- end
+
         SSL_load_error_strings();
         // TODO Deprecated???
         //SSLeay_add_tls_algorithms();

--- a/src/hurl/hurl.cc
+++ b/src/hurl/hurl.cc
@@ -2224,7 +2224,7 @@ state_top:
         {
                 return STATUS_DONE;
         }
-        switch(l_nconn->get_state())
+        switch(l_nconn->get_state()) // base class nconn function. returns m_nc_state
         {
         // -------------------------------------------------
         // STATE: FREE
@@ -2233,7 +2233,7 @@ state_top:
         {
                 //NDBG_PRINT("NC_STATE_FREE\n");
                 int32_t l_s;
-                l_s = l_nconn->ncsetup();
+                l_s = l_nconn->ncsetup(); //should call the implimentation in ns_hurl::nconn_tls for TLS connections. Not certain at this stage since l_nconn is a pointer of type nconn (base class) but it will actually point to a nconn_tls object for tls connections...
                 if(l_s != ns_hurl::nconn::NC_STATUS_OK)
                 {
                         TRC_ERROR("performing ncsetup\n");


### PR DESCRIPTION
The proposed changes (to add KTLS support)  are still in a draft stage.

Initial points for review/discussion:
1. In its current state, the proposed patch will ALWAYS enable KTLS if available. It may be worthwhile to make this configurable (possibly adding a command line argument?).
2. The BIO changes made do not appear to really be necessary for KTLS support and could possibly be omitted. This may be influenced by whether or not the "nc_set_accepting" code is ever hit (after an initial SSL conneciton, a subsequent call to SSL_set_fd will destroy the current BIOs attached to a TCP socket and create new ones - could influence KTLS behaviour). 
3. The edit to the CMakeLists.txt. file is a bit hacky (was done for a custom OpenSSL build done in a non-conventional way for a specific use case). It may be a good idea to amend or even omit this change.