### PR TITLE
Add documentation to init_with_url

### DIFF
--- a/src/hurl/hurl.cc
+++ b/src/hurl/hurl.cc
@@ -566,9 +566,9 @@ private:
         request& operator=(const request &);
 };
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Initialize an instance of request from a URL string
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   a_url the URL associated with this request instance
 //! ----------------------------------------------------------------------------
 int32_t request::init_with_url(const std::string &a_url)
 {

--- a/src/phurl/phurl.cc
+++ b/src/phurl/phurl.cc
@@ -301,9 +301,9 @@ private:
         request& operator=(const request &);
 };
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Initialize an instance of request from a URL string
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   a_url the URL associated with this request instance
 //! ----------------------------------------------------------------------------
 int32_t request::init_with_url(const std::string &a_url)
 {


### PR DESCRIPTION
Added some documentation to `init_with_url` function for both hurl and phurl.

...

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
