### PR TITLE
Added status code returns to nbq_write_request_line 

### DIFF
--- a/src/hurl/hurl.cc
+++ b/src/hurl/hurl.cc
@@ -354,9 +354,12 @@ double xstat_struct::stdev() const
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_request_line(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {
-        ao_q.write(a_buf, a_len);
-        ao_q.write("\r\n", strlen("\r\n"));
-        return 0;
+        if((ao_q.write(a_buf, a_len)) == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        ao_q.write("\r\n", strlen("\r\n"))
+        return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
 //! \details: TODO

--- a/src/phurl/phurl.cc
+++ b/src/phurl/phurl.cc
@@ -133,9 +133,12 @@ typedef std::list <t_phurl *> t_phurl_list_t;
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_request_line(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {
-        ao_q.write(a_buf, a_len);
+        if((ao_q.write(a_buf, a_len)) == STATUS_ERROR)
+        {
+            return STATUS_ERROR
+        }
         ao_q.write("\r\n", strlen("\r\n"));
-        return 0;
+        return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
 //! \details: TODO


### PR DESCRIPTION
`nbq::write()` returns `-1` when `b_write_add_avail()` fails. Returning status codes from `nbq_write_request_line` makes this error easier to catch.

Previously, this function always returned 0. The return value is not used by the caller as of now.

...
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
