### PR TITLE
Added status code returns to nbq_write_header and nbq_write_body

### DIFF
--- a/src/hurl/hurl.cc
+++ b/src/hurl/hurl.cc
@@ -376,11 +376,28 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
                                 const char *a_key_buf, uint32_t a_key_len,
                                 const char *a_val_buf, uint32_t a_val_len)
 {
-        ao_q.write(a_key_buf, a_key_len);
-        ao_q.write(": ", 2);
-        ao_q.write(a_val_buf, a_val_len);
-        ao_q.write("\r\n", 2);
-        return 0;
+        int64_t l_s;
+        l_s = ao_q.write(a_key_buf, a_key_len);
+        if(l_s == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        l_s = ao_q.write(": ", 2);
+        if(l_s == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        l_s = ao_q.write(a_val_buf, a_val_len);
+        if(l_s == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        l_s = ao_q.write("\r\n", 2);
+        if(l_s == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
 //! \details: TODO
@@ -389,9 +406,18 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_body(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {
-        ao_q.write("\r\n", strlen("\r\n"));
-        ao_q.write(a_buf, a_len);
-        return 0;
+        int64_t l_s;
+        l_s = ao_q.write("\r\n", strlen("\r\n"));
+        if(l_s == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        l_s = ao_q.write(a_buf, a_len);
+        if(l_s == STATUS_ERROR)
+        {
+                return STATUS_ERROR;
+        }
+        return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
 //! types

--- a/src/hurl/hurl.cc
+++ b/src/hurl/hurl.cc
@@ -382,7 +382,7 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
         {
                 return STATUS_ERROR;
         }
-        l_s = ao_q.write(": ", 2);
+        l_s = ao_q.write(": ", strlen(": "));
         if(l_s == STATUS_ERROR)
         {
                 return STATUS_ERROR;
@@ -392,7 +392,7 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
         {
                 return STATUS_ERROR;
         }
-        l_s = ao_q.write("\r\n", 2);
+        l_s = ao_q.write("\r\n", strlen("\r\n"));
         if(l_s == STATUS_ERROR)
         {
                 return STATUS_ERROR;

--- a/src/phurl/phurl.cc
+++ b/src/phurl/phurl.cc
@@ -161,7 +161,7 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
         {
                return STATUS_ERROR;
         }
-        l_s = ao_q.write(": ", 2);
+        l_s = ao_q.write(": ", strlen(": "));
         if(l_s == STATUS_ERROR)
         {
                return STATUS_ERROR;
@@ -171,7 +171,7 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
         {
                return STATUS_ERROR;
         }
-        l_s = ao_q.write("\r\n", 2);
+        l_s = ao_q.write("\r\n", strlen("\r\n"));
         if(l_s == STATUS_ERROR)
         {
               return STATUS_ERROR;

--- a/src/phurl/phurl.cc
+++ b/src/phurl/phurl.cc
@@ -155,11 +155,28 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
                          const char *a_key_buf, uint32_t a_key_len,
                          const char *a_val_buf, uint32_t a_val_len)
 {
-        ao_q.write(a_key_buf, a_key_len);
-        ao_q.write(": ", 2);
-        ao_q.write(a_val_buf, a_val_len);
-        ao_q.write("\r\n", 2);
-        return 0;
+        int64_t l_s;
+        l_s = ao_q.write(a_key_buf, a_key_len);
+        if(l_s == STATUS_ERROR)
+        {
+               return STATUS_ERROR;
+        }
+        l_s = ao_q.write(": ", 2);
+        if(l_s == STATUS_ERROR)
+        {
+               return STATUS_ERROR;
+        }
+        l_s = ao_q.write(a_val_buf, a_val_len);
+        if(l_s == STATUS_ERROR)
+        {
+               return STATUS_ERROR;
+        }
+        l_s = ao_q.write("\r\n", 2);
+        if(l_s == STATUS_ERROR)
+        {
+              return STATUS_ERROR;
+        }
+        return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
 //! \details: TODO
@@ -168,9 +185,18 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_body(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {
-        ao_q.write("\r\n", strlen("\r\n"));
-        ao_q.write(a_buf, a_len);
-        return 0;
+        int64_t l_s;
+        l_s = ao_q.write("\r\n", strlen("\r\n"));
+        if(l_s == STATUS_ERROR)
+        {
+              return STATUS_ERROR;
+        }
+        l_s = ao_q.write(a_buf, a_len);
+        if(l_s == STATUS_ERROR)
+        {
+              return STATUS_ERROR;
+        }
+        return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
 //! request object/meta


### PR DESCRIPTION
Making the same changes made to `nbq_write_request_line` in #33 to `nbq_write_header` and `nbq_write_body`.

Also changed `ao_q.write(": ", 2)` and `ao_q.write("\r\n", 2)` to make use of `strlen()` to find the length.

...
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
