### PR TITLE
Add documentation to nbq_write_* functions

### DIFF
--- a/src/hurl/hurl.cc
+++ b/src/hurl/hurl.cc
@@ -348,9 +348,11 @@ double xstat_struct::stdev() const
 //! nbq utilities
 //! ----------------------------------------------------------------------------
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Write a request line
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   ao_q an instance of nbq
+//! \param:   a_buf the buffer containing characters to be written
+//! \param:   a_len the length of a_buf
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_request_line(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {
@@ -368,9 +370,13 @@ static int32_t nbq_write_request_line(ns_hurl::nbq &ao_q, const char *a_buf, uin
         return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Write request header
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   ao_q an instance of nbq
+//! \param:   a_key_buf the buffer containing characters to be written for the key of the header
+//! \param:   a_key_len the length of a_key_buf
+//! \param:   a_val_buf the buffer containing characters to be written for the value of the header
+//! \param:   a_val_len the length of a_val_buf
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
                                 const char *a_key_buf, uint32_t a_key_len,
@@ -400,9 +406,11 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
         return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Write request body
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   ao_q an instance of nbq
+//! \param:   a_buf the buffer containing characters to be written
+//! \param:   a_len the length of a_buf
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_body(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {

--- a/src/phurl/phurl.cc
+++ b/src/phurl/phurl.cc
@@ -127,9 +127,11 @@ typedef std::list <t_phurl *> t_phurl_list_t;
 //! nbq utilities
 //! ----------------------------------------------------------------------------
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Write a request line
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   ao_q an instance of nbq
+//! \param:   a_buf the buffer containing characters to be written
+//! \param:   a_len the length of a_buf
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_request_line(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {
@@ -147,9 +149,13 @@ static int32_t nbq_write_request_line(ns_hurl::nbq &ao_q, const char *a_buf, uin
         return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Write request header
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   ao_q an instance of nbq
+//! \param:   a_key_buf the buffer containing characters to be written for the key of the header
+//! \param:   a_key_len the length of a_key_buf
+//! \param:   a_val_buf the buffer containing characters to be written for the value of the header
+//! \param:   a_val_len the length of a_val_buf
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
                          const char *a_key_buf, uint32_t a_key_len,
@@ -179,9 +185,11 @@ static int32_t nbq_write_header(ns_hurl::nbq &ao_q,
         return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------
-//! \details: TODO
-//! \return:  TODO
-//! \param:   TODO
+//! \details: Write request body
+//! \return:  STATUS_ERROR or STATUS_OK
+//! \param:   ao_q an instance of nbq
+//! \param:   a_buf the buffer containing characters to be written
+//! \param:   a_len the length of a_buf
 //! ----------------------------------------------------------------------------
 static int32_t nbq_write_body(ns_hurl::nbq &ao_q, const char *a_buf, uint32_t a_len)
 {


### PR DESCRIPTION
Add documentation to `nbq_write_request_line`, `nbq_write_header` and `nbq_write_body` functions.

...
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
